### PR TITLE
Optimising the home screen for mobile

### DIFF
--- a/src/styles/GalleryBannerStyles.css
+++ b/src/styles/GalleryBannerStyles.css
@@ -59,7 +59,7 @@
     font-style: italic;
 }
 
-@media only screen and (min-width: 400px) {
+@media screen and (min-width: 800px) {
     .image-gallery {
       flex-direction: row;
     }

--- a/src/styles/NavBarStyles.css
+++ b/src/styles/NavBarStyles.css
@@ -133,7 +133,7 @@
         padding-bottom: 30px;
         width: 100%;
         margin-right: 0px;
-        right: -180vh;
+        right: -180vw;
         top: -10px;
         position: absolute;
         transition: all 0.5s ease;

--- a/src/styles/WelcomeImageStyles.css
+++ b/src/styles/WelcomeImageStyles.css
@@ -34,7 +34,7 @@
 
 @media only screen and (max-width: 770px) {
     .mainText {
-        padding-top: 28px;
+        padding-top: 80px;
         font-size: 48px;
         padding-bottom: 20px;
     }


### PR DESCRIPTION
1. Updating the gallery banner so that when on mobile the images are in one column and not in two
2. Updating the menu so that it doesn't show up when the screen is very wide and short in height