### PR TITLE
fix photo album counts after bulk move

### DIFF
--- a/src/pages/admin/PhotosPage.test.tsx
+++ b/src/pages/admin/PhotosPage.test.tsx
@@ -204,6 +204,28 @@ describe('PhotosPage', () => {
     expect(JSON.parse(String(init.body))).toMatchObject({ albumId: null });
   });
 
+  it('updates album counts immediately after a bulk move', async () => {
+    const user = userEvent.setup();
+    adminFetchMock.mockResolvedValueOnce({ ...createPhotos()[0], albumId: 'album-2', albumName: 'Cities' });
+    adminFetchMock.mockResolvedValueOnce({ ...createPhotos()[1], albumId: 'album-2', albumName: 'Cities' });
+
+    render(<PhotosPage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Open landscape.jpg' }), { ctrlKey: true });
+    fireEvent.click(screen.getByRole('button', { name: 'Open waterfall.jpg' }), { ctrlKey: true });
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Bulk move destination' }), { target: { value: 'album-2' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Bulk move' }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Open album Landscapes' })).toHaveTextContent('0 photos');
+      expect(screen.getByRole('button', { name: 'Open album Cities' })).toHaveTextContent('3 photos');
+    });
+  });
+
   it('filters photos that are not in any album', async () => {
     loadPhotosMock.mockResolvedValue([
       ...createPhotos(),

--- a/src/pages/admin/PhotosPage.tsx
+++ b/src/pages/admin/PhotosPage.tsx
@@ -210,6 +210,7 @@ export default function PhotosPage() {
   }
 
   async function movePhoto(photo: AdminPhoto, albumId: string | null) {
+    const previousAlbumId = photo.albumId;
     setSaving(true);
     setError(null);
     try {
@@ -218,6 +219,7 @@ export default function PhotosPage() {
         body: JSON.stringify(buildPhotoPayload(photo, albumId)),
       });
       setPhotos((current) => current.map((item) => item.id === updated.id ? updated : item));
+      setAlbums((current) => applyAlbumPhotoMove(current, previousAlbumId, updated.albumId, updated.id));
       setSelectedPhotoId(updated.id);
       setMessage("Photo moved");
     } catch (err) {
@@ -230,6 +232,7 @@ export default function PhotosPage() {
   async function bulkMove(albumId: string | null) {
     if (selectedPhotos.length === 0) return;
     const photosToMove = [...selectedPhotos];
+    const previousAlbums = new Map(photosToMove.map((photo) => [photo.id, photo.albumId]));
     setSaving(true);
     setError(null);
     try {
@@ -243,6 +246,13 @@ export default function PhotosPage() {
       }
 
       setPhotos((current) => current.map((photo) => updatedPhotos.find((item) => item.id === photo.id) ?? photo));
+      setAlbums((current) => {
+        const movedPhotosById = new Map(updatedPhotos.map((photo) => [photo.id, photo]));
+        return photosToMove.reduce((nextAlbums, originalPhoto) => {
+          const updated = movedPhotosById.get(originalPhoto.id);
+          return updated ? applyAlbumPhotoMove(nextAlbums, previousAlbums.get(originalPhoto.id) ?? null, updated.albumId, updated.id) : nextAlbums;
+        }, current);
+      });
       setMessage(`Moved ${photosToMove.length} photos`);
       clearSelection();
       setBulkMoveAlbumId(bulkMoveUnsetValue);
@@ -302,6 +312,7 @@ export default function PhotosPage() {
       clearSelection();
 
       if (selectedPhotos.length > 0) {
+        const previousAlbums = new Map(selectedPhotos.map((photo) => [photo.id, photo.albumId]));
         const updatedPhotos: AdminPhoto[] = [];
         for (const photo of [...selectedPhotos]) {
           const updated = await adminFetch<AdminPhoto>(`/api/photos/${photo.id}`, {
@@ -312,6 +323,14 @@ export default function PhotosPage() {
         }
 
         setPhotos((current) => current.map((photo) => updatedPhotos.find((item) => item.id === photo.id) ?? photo));
+        setAlbums((current) => {
+          const movedPhotosById = new Map(updatedPhotos.map((photo) => [photo.id, photo]));
+          const withCreatedAlbum = [created, ...current.filter((album) => album.id !== created.id)];
+          return selectedPhotos.reduce((nextAlbums, originalPhoto) => {
+            const updated = movedPhotosById.get(originalPhoto.id);
+            return updated ? applyAlbumPhotoMove(nextAlbums, previousAlbums.get(originalPhoto.id) ?? null, updated.albumId, updated.id) : nextAlbums;
+          }, withCreatedAlbum);
+        });
         setBulkMoveAlbumId(bulkMoveUnsetValue);
         setMessage(`Album created and ${updatedPhotos.length} photo${updatedPhotos.length === 1 ? "" : "s"} moved`);
       } else if (selectedPhoto) {
@@ -320,6 +339,7 @@ export default function PhotosPage() {
           body: JSON.stringify(buildPhotoPayload(selectedPhoto, created.id)),
         });
         setPhotos((current) => current.map((photo) => photo.id === updated.id ? updated : photo));
+        setAlbums((current) => applyAlbumPhotoMove([created, ...current.filter((album) => album.id !== created.id)], selectedPhoto.albumId, updated.albumId, updated.id));
         setSelectedPhotoId(updated.id);
         setMessage(`Album created and ${updated.fileName} moved`);
       } else {
@@ -330,6 +350,32 @@ export default function PhotosPage() {
     } finally {
       setSaving(false);
     }
+  }
+
+  function applyAlbumPhotoMove(albumsState: AdminAlbum[], previousAlbumId: string | null, nextAlbumId: string | null, movedPhotoId: string) {
+    if (previousAlbumId === nextAlbumId) {
+      return albumsState.map((album) => album.id === nextAlbumId && album.coverPhotoId === null ? { ...album, coverPhotoId: movedPhotoId, photosCount: album.photosCount } : album);
+    }
+
+    return albumsState.map((album) => {
+      if (album.id === previousAlbumId) {
+        return {
+          ...album,
+          photosCount: Math.max(0, album.photosCount - 1),
+          coverPhotoId: album.coverPhotoId === movedPhotoId ? null : album.coverPhotoId,
+        };
+      }
+
+      if (album.id === nextAlbumId) {
+        return {
+          ...album,
+          photosCount: album.photosCount + 1,
+          coverPhotoId: album.coverPhotoId ?? movedPhotoId,
+        };
+      }
+
+      return album;
+    });
   }
 
   return (


### PR DESCRIPTION
## Summary\n- Update album counts and cover state immediately after photo moves in the admin photo manager\n- Keep bulk move, single move, and create-and-move flows in sync without requiring a manual refresh\n- Add a regression test for the bulk move album counts\n\nCloses #57