### PR TITLE
feat post-upload metadata review flow

### DIFF
--- a/src/pages/admin/PhotosPage.test.tsx
+++ b/src/pages/admin/PhotosPage.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import PhotosPage from './PhotosPage';
 import type { AdminAlbum, AdminPhoto } from './types';
@@ -118,8 +119,18 @@ describe('PhotosPage', () => {
     loadPhotosMock.mockResolvedValue(createPhotos());
   });
 
+  function renderPhotosPage(initialEntries = ['/admin/photos']) {
+    return render(
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path="/admin/photos" element={<PhotosPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
   it('starts in browse mode and opens the editor only after clicking a photo', async () => {
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     expect(await screen.findByRole('button', { name: 'Browse all photos' })).toBeInTheDocument();
     expect(screen.queryByText('Edit photo')).not.toBeInTheDocument();
@@ -130,7 +141,7 @@ describe('PhotosPage', () => {
   });
 
   it('shows album-first navigation and filters the grid by album', async () => {
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     expect(await screen.findByRole('button', { name: 'Open album Landscapes' })).toBeInTheDocument();
 
@@ -141,7 +152,7 @@ describe('PhotosPage', () => {
   });
 
   it('saves the selected photo metadata', async () => {
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Open landscape.jpg' }));
 
@@ -181,7 +192,7 @@ describe('PhotosPage', () => {
       return Promise.resolve(undefined);
     });
 
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     const firstPhoto = await screen.findByRole('button', { name: 'Open landscape.jpg' });
     const secondPhoto = screen.getByRole('button', { name: 'Open waterfall.jpg' });
@@ -209,7 +220,7 @@ describe('PhotosPage', () => {
     adminFetchMock.mockResolvedValueOnce({ ...createPhotos()[0], albumId: 'album-2', albumName: 'Cities' });
     adminFetchMock.mockResolvedValueOnce({ ...createPhotos()[1], albumId: 'album-2', albumName: 'Cities' });
 
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Open landscape.jpg' }), { ctrlKey: true });
     fireEvent.click(screen.getByRole('button', { name: 'Open waterfall.jpg' }), { ctrlKey: true });
@@ -249,7 +260,7 @@ describe('PhotosPage', () => {
       },
     ]);
 
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Browse photos with no album' }));
 
@@ -274,7 +285,7 @@ describe('PhotosPage', () => {
       .mockResolvedValueOnce({ ...createPhotos()[0], albumId: 'album-3', albumName: 'Birds' })
       .mockResolvedValueOnce({ ...createPhotos()[1], albumId: 'album-3', albumName: 'Birds' });
 
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Open landscape.jpg' }), { ctrlKey: true });
     fireEvent.click(screen.getByRole('button', { name: 'Open waterfall.jpg' }), { ctrlKey: true });
@@ -296,7 +307,7 @@ describe('PhotosPage', () => {
   });
 
   it('supports shift-click range selection', async () => {
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     const firstPhoto = await screen.findByRole('button', { name: 'Open landscape.jpg' });
     const secondPhoto = screen.getByRole('button', { name: 'Open waterfall.jpg' });
@@ -311,7 +322,7 @@ describe('PhotosPage', () => {
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     adminFetchMock.mockResolvedValue(undefined);
 
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Open landscape.jpg' }), { ctrlKey: true });
     fireEvent.click(screen.getByRole('button', { name: 'Open waterfall.jpg' }), { ctrlKey: true });
@@ -328,7 +339,7 @@ describe('PhotosPage', () => {
   });
 
   it('clears hidden selection when the search scope changes', async () => {
-    render(<PhotosPage />);
+    renderPhotosPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Open landscape.jpg' }), { ctrlKey: true });
     fireEvent.click(screen.getByRole('button', { name: 'Open waterfall.jpg' }), { ctrlKey: true });
@@ -338,5 +349,12 @@ describe('PhotosPage', () => {
     fireEvent.change(screen.getByRole('textbox', { name: 'Search photos' }), { target: { value: 'city' } });
 
     expect(screen.getByText('0 selected')).toBeInTheDocument();
+  });
+
+  it('opens the first reviewed photo from the query string', async () => {
+    renderPhotosPage(['/admin/photos?review=photo-2,photo-1']);
+
+    expect(await screen.findByText('Edit photo')).toBeInTheDocument();
+    expect(screen.getByText('waterfall.jpg')).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/PhotosPage.tsx
+++ b/src/pages/admin/PhotosPage.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, KeyboardEvent, MouseEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { AdminShell } from "./AdminShell";
 import { adminFetch, loadAlbums, loadPhotos } from "./api";
 import type { AdminAlbum, AdminPhoto } from "./types";
@@ -26,6 +27,7 @@ function buildPhotoPayload(photo: AdminPhoto, albumId: string | null = photo.alb
 }
 
 export default function PhotosPage() {
+  const location = useLocation();
   const [albums, setAlbums] = useState<AdminAlbum[]>([]);
   const [photos, setPhotos] = useState<AdminPhoto[]>([]);
   const [activeAlbumId, setActiveAlbumId] = useState<string>(allPhotosAlbumId);
@@ -44,6 +46,10 @@ export default function PhotosPage() {
   const selectedPhotoIdsRef = useRef<string[]>([]);
   const selectedPhotoIdRef = useRef("");
   const lastSelectedPhotoIdRef = useRef<string | null>(null);
+  const reviewTargetIds = useMemo(() => {
+    const reviewParam = new URLSearchParams(location.search).get("review");
+    return reviewParam ? reviewParam.split(",").map((item) => item.trim()).filter(Boolean) : [];
+  }, [location.search]);
 
   const selectedPhoto = useMemo(() => photos.find((photo) => photo.id === selectedPhotoId) ?? null, [photos, selectedPhotoId]);
   const activeAlbum = useMemo(() => albums.find((album) => album.id === activeAlbumId) ?? null, [activeAlbumId, albums]);
@@ -105,6 +111,19 @@ export default function PhotosPage() {
 
     commitSelection([], "", null);
   }, [searchTerm]);
+
+  useEffect(() => {
+    if (reviewTargetIds.length === 0 || photos.length === 0) {
+      return;
+    }
+
+    const firstReviewPhoto = photos.find((photo) => reviewTargetIds.includes(photo.id)) ?? null;
+    if (!firstReviewPhoto) {
+      return;
+    }
+
+    setSelectedPhotoId(firstReviewPhoto.id);
+  }, [photos, reviewTargetIds]);
 
   async function refresh() {
     setLoading(true);

--- a/src/pages/admin/UploadPage.test.tsx
+++ b/src/pages/admin/UploadPage.test.tsx
@@ -174,7 +174,7 @@ describe('UploadPage', () => {
     expect(((secondInit.body as FormData).get('file') as File).name).toBe('fresh-2.jpg');
     expect((secondInit.body as FormData).get('albumId')).toBe('album-1');
 
-    expect(await screen.findByText('/admin/photos?review=photo-3')).toBeInTheDocument();
+    expect(await screen.findByText('/admin/photos?review=photo-3%2Cphoto-4')).toBeInTheDocument();
   });
 
   it('can create a new batch album before queueing files', async () => {
@@ -292,18 +292,6 @@ describe('UploadPage', () => {
     });
 
     expect(await screen.findByText('/admin/photos?review=photo-3')).toBeInTheDocument();
-
-    await act(async () => {
-      await user.upload(screen.getByLabelText('Queue photos'), [
-        new File(['image-2'], 'second.jpg', { type: 'image/jpeg' }),
-      ]);
-    });
-
-    await waitFor(() => {
-      expect(adminFetchMock).toHaveBeenCalledTimes(2);
-    });
-
-    expect(await screen.findByText('/admin/photos?review=photo-3')).toBeInTheDocument();
   });
 
   it('shows detected metadata for a selected recent upload', async () => {
@@ -354,7 +342,7 @@ describe('UploadPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText('photo manager')).toBeInTheDocument();
+      expect(screen.getByText('/admin/photos?review=photo-3')).toBeInTheDocument();
     });
   });
 });

--- a/src/pages/admin/UploadPage.test.tsx
+++ b/src/pages/admin/UploadPage.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import UploadPage from './UploadPage';
 import type { AdminAlbum, AdminPhoto } from './types';
 
@@ -10,6 +11,12 @@ const loadPhotosMock = vi.fn();
 const adminFetchMock = vi.fn();
 const createObjectUrlMock = vi.fn();
 const revokeObjectUrlMock = vi.fn();
+
+function LocationProbe() {
+  const location = useLocation();
+
+  return <div>{`${location.pathname}${location.search}`}</div>;
+}
 
 vi.mock('./api', () => ({
   loadAlbums: (...args: unknown[]) => loadAlbumsMock(...args),
@@ -109,7 +116,7 @@ describe('UploadPage', () => {
         <MemoryRouter initialEntries={['/admin/upload']}>
           <Routes>
             <Route path="/admin/upload" element={<UploadPage />} />
-            <Route path="/admin/photos" element={<div>photo manager</div>} />
+            <Route path="/admin/photos" element={<LocationProbe />} />
           </Routes>
         </MemoryRouter>
       );
@@ -167,7 +174,7 @@ describe('UploadPage', () => {
     expect(((secondInit.body as FormData).get('file') as File).name).toBe('fresh-2.jpg');
     expect((secondInit.body as FormData).get('albumId')).toBe('album-1');
 
-    expect(screen.getByText('Edit photo')).toBeInTheDocument();
+    expect(await screen.findByText('/admin/photos?review=photo-3')).toBeInTheDocument();
   });
 
   it('can create a new batch album before queueing files', async () => {
@@ -243,7 +250,7 @@ describe('UploadPage', () => {
       expect(adminFetchMock).toHaveBeenCalledTimes(2);
     });
 
-    expect(screen.getByText('Edit photo')).toBeInTheDocument();
+    expect(await screen.findByText('/admin/photos?review=photo-3')).toBeInTheDocument();
   });
 
   it('marks malformed upload responses as failed instead of crashing', async () => {
@@ -284,7 +291,7 @@ describe('UploadPage', () => {
       ]);
     });
 
-    expect(screen.getByRole('heading', { name: 'Upload' })).toBeInTheDocument();
+    expect(await screen.findByText('/admin/photos?review=photo-3')).toBeInTheDocument();
 
     await act(async () => {
       await user.upload(screen.getByLabelText('Queue photos'), [
@@ -296,7 +303,7 @@ describe('UploadPage', () => {
       expect(adminFetchMock).toHaveBeenCalledTimes(2);
     });
 
-    expect(screen.getByText('Edit photo')).toBeInTheDocument();
+    expect(await screen.findByText('/admin/photos?review=photo-3')).toBeInTheDocument();
   });
 
   it('shows detected metadata for a selected recent upload', async () => {

--- a/src/pages/admin/UploadPage.test.tsx
+++ b/src/pages/admin/UploadPage.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import UploadPage from './UploadPage';
 import type { AdminAlbum, AdminPhoto } from './types';
 
@@ -104,7 +105,14 @@ describe('UploadPage', () => {
 
   async function renderUploadPage() {
     await act(async () => {
-      render(<UploadPage />);
+      render(
+        <MemoryRouter initialEntries={['/admin/upload']}>
+          <Routes>
+            <Route path="/admin/upload" element={<UploadPage />} />
+            <Route path="/admin/photos" element={<div>photo manager</div>} />
+          </Routes>
+        </MemoryRouter>
+      );
     });
 
     expect(await screen.findByText('Batch upload')).toBeInTheDocument();
@@ -159,8 +167,7 @@ describe('UploadPage', () => {
     expect(((secondInit.body as FormData).get('file') as File).name).toBe('fresh-2.jpg');
     expect((secondInit.body as FormData).get('albumId')).toBe('album-1');
 
-    expect(await screen.findByText('Upload complete. 2 photos uploaded.')).toBeInTheDocument();
-    expect(screen.getByText('Taken at: Detected')).toBeInTheDocument();
+    expect(screen.getByText('Edit photo')).toBeInTheDocument();
   });
 
   it('can create a new batch album before queueing files', async () => {
@@ -236,7 +243,7 @@ describe('UploadPage', () => {
       expect(adminFetchMock).toHaveBeenCalledTimes(2);
     });
 
-    expect(await screen.findByText('Upload complete. 1 photo uploaded.')).toBeInTheDocument();
+    expect(screen.getByText('Edit photo')).toBeInTheDocument();
   });
 
   it('marks malformed upload responses as failed instead of crashing', async () => {
@@ -277,7 +284,7 @@ describe('UploadPage', () => {
       ]);
     });
 
-    expect(await screen.findByText('Upload complete. 1 photo uploaded.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Upload' })).toBeInTheDocument();
 
     await act(async () => {
       await user.upload(screen.getByLabelText('Queue photos'), [
@@ -289,8 +296,7 @@ describe('UploadPage', () => {
       expect(adminFetchMock).toHaveBeenCalledTimes(2);
     });
 
-    expect(screen.getByText('Upload complete. 1 photo uploaded.')).toBeInTheDocument();
-    expect(screen.queryByText('Upload complete. 2 photos uploaded.')).not.toBeInTheDocument();
+    expect(screen.getByText('Edit photo')).toBeInTheDocument();
   });
 
   it('shows detected metadata for a selected recent upload', async () => {
@@ -309,9 +315,39 @@ describe('UploadPage', () => {
     loadAlbumsMock.mockRejectedValue(new Error('Failed to load upload data'));
 
     await act(async () => {
-      render(<UploadPage />);
+      render(
+        <MemoryRouter initialEntries={['/admin/upload']}>
+          <Routes>
+            <Route path="/admin/upload" element={<UploadPage />} />
+            <Route path="/admin/photos" element={<div>photo manager</div>} />
+          </Routes>
+        </MemoryRouter>
+      );
     });
 
     expect(await screen.findByText('Failed to load upload data')).toBeInTheDocument();
+  });
+
+  it('opens the photo manager after a batch upload completes', async () => {
+    const user = userEvent.setup();
+    adminFetchMock.mockResolvedValue({
+      ...createPhotos()[0],
+      id: 'photo-3',
+      fileName: 'review.jpg',
+      albumId: 'album-1',
+      albumName: 'Landscapes',
+    });
+
+    await renderUploadPage();
+
+    await act(async () => {
+      await user.upload(screen.getByLabelText('Queue photos'), [
+        new File(['image-1'], 'review.jpg', { type: 'image/jpeg' }),
+      ]);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('photo manager')).toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/admin/UploadPage.tsx
+++ b/src/pages/admin/UploadPage.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { AdminShell } from "./AdminShell";
 import { adminFetch, loadAlbums, loadPhotos } from "./api";
 import type { AdminAlbum, AdminPhoto } from "./types";
@@ -59,6 +60,7 @@ function getStatusClassName(item: QueuedUpload) {
 }
 
 export default function UploadPage() {
+  const navigate = useNavigate();
   const [albums, setAlbums] = useState<AdminAlbum[]>([]);
   const [photos, setPhotos] = useState<AdminPhoto[]>([]);
   const [loading, setLoading] = useState(true);
@@ -75,6 +77,8 @@ export default function UploadPage() {
   const queueRef = useRef<QueuedUpload[]>([]);
   const uploadingRef = useRef(false);
   const uploadRunSummaryRef = useRef({ uploaded: 0, failed: 0 });
+  const uploadedBatchPhotoIdsRef = useRef<string[]>([]);
+  const reviewNavigationTriggeredRef = useRef(false);
 
   const selectedPhoto = photos.find((photo) => photo.id === selectedPhotoId) ?? null;
   const queueSummary = useMemo(() => ({
@@ -95,6 +99,12 @@ export default function UploadPage() {
 
   useEffect(() => {
     uploadingRef.current = uploading;
+  }, [uploading]);
+
+  useEffect(() => {
+    if (!uploading) {
+      reviewNavigationTriggeredRef.current = false;
+    }
   }, [uploading]);
 
   useEffect(() => {
@@ -119,6 +129,12 @@ export default function UploadPage() {
     if (nextQueued) {
       void uploadQueuedItem(nextQueued.id);
       return;
+    }
+
+    const uploadedBatchPhotoIds = uploadedBatchPhotoIdsRef.current;
+    if (!reviewNavigationTriggeredRef.current && uploadedBatchPhotoIds.length > 0) {
+      reviewNavigationTriggeredRef.current = true;
+      navigate(`/admin/photos?review=${encodeURIComponent(uploadedBatchPhotoIds.join(","))}`);
     }
 
     uploadingRef.current = false;
@@ -165,6 +181,7 @@ export default function UploadPage() {
 
     if (!uploadingRef.current) {
       uploadRunSummaryRef.current = { uploaded: 0, failed: 0 };
+      uploadedBatchPhotoIdsRef.current = [];
     }
 
     setQueue((current) => [...current, ...queued]);
@@ -282,6 +299,7 @@ export default function UploadPage() {
       }
 
       uploadRunSummaryRef.current.uploaded += 1;
+      uploadedBatchPhotoIdsRef.current.push(result.id);
       setError(null);
 
       setQueue((current) => current.map((entry) => entry.id === id


### PR DESCRIPTION
## Summary\n- Navigate to the photo manager when a batch upload completes\n- Pass the uploaded photo ids through the route so the first new photo opens in review mode\n- Keep the batch upload and photo manager flows connected for immediate metadata cleanup\n\nCloses #54