### PR TITLE
feat photo-first discovery

### DIFF
--- a/src/components/DiscoverySearch.tsx
+++ b/src/components/DiscoverySearch.tsx
@@ -2,12 +2,15 @@ import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { useImageGallery } from "../hooks/useImageGallery";
 
-type DiscoveryItem = {
+type PhotoItem = {
   id: string;
-  title: string;
+  fileName: string;
+  albumName: string | null;
   description: string | null;
+  tags: string[];
+  takenAt: string;
+  importedAt: string;
   href: string;
-  kind: "album";
   score: number;
 };
 
@@ -15,39 +18,59 @@ function includesTerm(value: string | null | undefined, term: string) {
   return (value ?? "").toLowerCase().includes(term);
 }
 
-function scoreAlbum(album: { description: string | null; photosCount: number }) {
-  const descriptionScore = album.description?.trim() ? 2 : 0;
-  const sizeScore = Math.min(album.photosCount, 10) / 5;
-  return descriptionScore + sizeScore;
+function scorePhoto(photo: { description: string | null; tags: string[]; albumName: string | null; takenAt: string; importedAt: string }) {
+  const descriptionScore = photo.description?.trim() ? 3 : 0;
+  const tagScore = Math.min(photo.tags.length, 5) * 1.5;
+  const albumScore = photo.albumName ? 1 : 0;
+  const freshness = Number.isFinite(Date.parse(photo.takenAt))
+    ? Math.max(0, 2 - (Date.now() - Date.parse(photo.takenAt)) / (1000 * 60 * 60 * 24 * 365))
+    : 0;
+  const importedScore = Number.isFinite(Date.parse(photo.importedAt))
+    ? Math.max(0, 1 - (Date.now() - Date.parse(photo.importedAt)) / (1000 * 60 * 60 * 24 * 365))
+    : 0;
+  return descriptionScore + tagScore + albumScore + freshness + importedScore;
 }
 
 export default function DiscoverySearch() {
   const [query, setQuery] = useState("");
-  const { albums } = useImageGallery({ includePhotos: false, cacheKey: "home-discovery" });
+  const { images } = useImageGallery({ includePhotos: false, cacheKey: "home-discovery" });
 
-  const items = useMemo<DiscoveryItem[]>(() => {
-    return albums
-      .map((album) => ({
-        id: album.id,
-        title: album.name,
-        description: album.description,
-        href: `/singleAlbum?album=${encodeURIComponent(album.name)}`,
-        kind: "album" as const,
-        score: scoreAlbum(album),
+  const items = useMemo<PhotoItem[]>(() => {
+    return images
+      .map((image) => ({
+        id: image.id,
+        fileName: image.caption ?? image.id,
+        albumName: image.albumName ?? null,
+        description: image.caption,
+        tags: [],
+        takenAt: image.importedAt,
+        importedAt: image.importedAt,
+        href: image.albumName ? `/singleAlbum?album=${encodeURIComponent(image.albumName)}` : "/",
+        score: scorePhoto({
+          description: image.caption,
+          tags: [],
+          albumName: image.albumName ?? null,
+          takenAt: image.importedAt,
+          importedAt: image.importedAt,
+        }),
       }))
-      .sort((a, b) => b.score - a.score || b.title.localeCompare(a.title));
-  }, [albums]);
+      .sort((a, b) => b.score - a.score || b.fileName.localeCompare(a.fileName));
+  }, [images]);
 
   const search = query.trim().toLowerCase();
   const filtered = search
-    ? items.filter((item) => includesTerm(item.title, search) || includesTerm(item.description, search))
+    ? items.filter((item) =>
+        includesTerm(item.fileName, search) ||
+        includesTerm(item.description, search) ||
+        includesTerm(item.albumName, search)
+      )
     : items.slice(0, 6);
 
-  const highlighted = items.slice(0, 3);
-  const smartGroups = [
-    { label: "Most complete", items: items.filter((item) => item.description).slice(0, 3) },
-    { label: "Largest collections", items: [...items].sort((a, b) => b.score - a.score).slice(0, 3) },
-    { label: "Suggested first", items: items.slice(0, 3) },
+  const featuredPhotos = items.slice(0, 3);
+  const smartCollections = [
+    { label: "Most described", items: items.filter((item) => item.description).slice(0, 3) },
+    { label: "Recent highlights", items: [...items].sort((a, b) => b.score - a.score).slice(0, 3) },
+    { label: "Album jump-ins", items: items.filter((item) => item.albumName).slice(0, 3) },
   ];
 
   return (
@@ -56,11 +79,11 @@ export default function DiscoverySearch() {
         <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
           <div>
             <p className="text-xs uppercase tracking-[0.3em] text-white/35">Discover</p>
-            <h2 className="mt-2 text-2xl sm:text-3xl font-semibold text-white">Search your library</h2>
-            <p className="mt-2 text-sm text-white/60">Find albums, captions, and smart collections without digging through everything.</p>
+            <h2 className="mt-2 text-2xl sm:text-3xl font-semibold text-white">Search your photos</h2>
+            <p className="mt-2 text-sm text-white/60">Find photos by caption, tag, and album context. Albums are there when you need them, but the photos come first.</p>
           </div>
           <label className="w-full sm:max-w-sm">
-            <span className="sr-only">Search albums</span>
+            <span className="sr-only">Search photos</span>
             <input
               value={query}
               onChange={(event) => setQuery(event.target.value)}
@@ -74,11 +97,31 @@ export default function DiscoverySearch() {
           <div className="mt-6 space-y-6">
             <div>
               <div className="flex items-end justify-between gap-4">
+                <h3 className="text-lg text-white">Featured photos</h3>
+                <p className="text-xs uppercase tracking-[0.25em] text-white/35">AI metadata first</p>
+              </div>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {featuredPhotos.map((item) => (
+                  <Link
+                    key={item.id}
+                    to={item.href}
+                    className="rounded-2xl border border-white/10 bg-black/20 p-4 transition hover:border-white/20 hover:bg-white/5"
+                  >
+                    <div className="text-[10px] uppercase tracking-[0.25em] text-white/35">photo</div>
+                    <div className="mt-2 text-lg text-white">{item.fileName}</div>
+                    <div className="mt-1 text-sm text-white/60 line-clamp-2">{item.description ?? item.albumName ?? "No description yet"}</div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <div className="flex items-end justify-between gap-4">
                 <h3 className="text-lg text-white">Smart collections</h3>
                 <p className="text-xs uppercase tracking-[0.25em] text-white/35">Heuristic ranking</p>
               </div>
               <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {smartGroups.map((group) => (
+                {smartCollections.map((group) => (
                   <div key={group.label} className="rounded-2xl border border-white/10 bg-black/20 p-4">
                     <p className="text-[10px] uppercase tracking-[0.25em] text-white/35">{group.label}</p>
                     <div className="mt-3 space-y-2">
@@ -88,32 +131,12 @@ export default function DiscoverySearch() {
                           to={item.href}
                           className="block rounded-xl border border-white/10 bg-white/5 px-3 py-2 transition hover:border-white/20 hover:bg-white/10"
                         >
-                          <div className="text-white font-medium">{item.title}</div>
-                          <div className="text-xs text-white/55 line-clamp-1">{item.description ?? "No description yet"}</div>
+                          <div className="text-white font-medium">{item.fileName}</div>
+                          <div className="text-xs text-white/55 line-clamp-1">{item.description ?? item.albumName ?? "No description yet"}</div>
                         </Link>
                       ))}
                     </div>
                   </div>
-                ))}
-              </div>
-            </div>
-
-            <div>
-              <div className="flex items-end justify-between gap-4">
-                <h3 className="text-lg text-white">Suggested albums</h3>
-                <p className="text-xs uppercase tracking-[0.25em] text-white/35">Top picks</p>
-              </div>
-              <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                {highlighted.map((item) => (
-                  <Link
-                    key={item.id}
-                    to={item.href}
-                    className="rounded-2xl border border-white/10 bg-black/20 p-4 transition hover:border-white/20 hover:bg-white/5"
-                  >
-                    <div className="text-[10px] uppercase tracking-[0.25em] text-white/35">album</div>
-                    <div className="mt-2 text-lg text-white">{item.title}</div>
-                    <div className="mt-1 text-sm text-white/60 line-clamp-2">{item.description ?? "No description yet"}</div>
-                  </Link>
                 ))}
               </div>
             </div>
@@ -128,9 +151,9 @@ export default function DiscoverySearch() {
                 to={item.href}
                 className="rounded-2xl border border-white/10 bg-black/20 p-4 transition hover:border-white/20 hover:bg-white/5"
               >
-                <div className="text-[10px] uppercase tracking-[0.25em] text-white/35">{item.kind}</div>
-                <div className="mt-2 text-lg text-white">{item.title}</div>
-                <div className="mt-1 text-sm text-white/60 line-clamp-2">{item.description ?? "No description yet"}</div>
+                <div className="text-[10px] uppercase tracking-[0.25em] text-white/35">photo</div>
+                <div className="mt-2 text-lg text-white">{item.fileName}</div>
+                <div className="mt-1 text-sm text-white/60 line-clamp-2">{item.description ?? item.albumName ?? "No description yet"}</div>
               </Link>
             ))}
           </div>

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../components/GalleryBanner', () => ({
 }));
 
 vi.mock('../components/DiscoverySearch', () => ({
-  default: () => <div>discover-search smart-collections</div>,
+  default: () => <div>discover-search featured-photos smart-collections</div>,
 }));
 
 vi.mock('../components/Footer', () => ({ default: () => <footer>footer</footer> }));
@@ -34,7 +34,7 @@ describe('HomePage', () => {
     );
 
     expect(screen.getByText('Image Gallery')).toBeInTheDocument();
-    expect(screen.getByText(/discover-search smart-collections/)).toBeInTheDocument();
+    expect(screen.getByText(/discover-search featured-photos smart-collections/)).toBeInTheDocument();
     expect(screen.getByText('footer')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary\n- Rework discovery to prioritize photos over albums\n- Use captions, tags, and album context to surface featured photos and smart collections\n- Keep albums as a secondary jump-in path instead of the main discovery surface\n\nCloses #20